### PR TITLE
Send EHLO when establishing outgoing SMTP connection

### DIFF
--- a/WhatsAppEmailForwarder.py
+++ b/WhatsAppEmailForwarder.py
@@ -68,7 +68,7 @@ from yowsup.layers.protocol_receipts.protocolentities \
         import OutgoingReceiptProtocolEntity
 from yowsup.layers.protocol_presence import YowPresenceProtocolLayer
 from yowsup.layers.stanzaregulator import YowStanzaRegulator
-#from yowsup.layers.axolotl import YowAxolotlLayer # FIXME
+from yowsup.layers.axolotl import YowAxolotlLayer # FIXME
 from yowsup.stacks import YowStack, YOWSUP_CORE_LAYERS
 
 
@@ -136,17 +136,19 @@ class MailLayer(YowInterfaceLayer):
             s_class = smtplib.SMTP
 
         s = s_class(confout['host'], confout.get('port', 25))
-
-        if confout.get('smtp_user', None):
-            s.login(confout.get('smtp_user'), confout.get('smtp_pass'))
+        s.ehlo();
 
         if not confout.get('force_startssl', True):
             try:
                 s.starttls() # Some servers require it, let's try
+                s.ehlo();
             except smtplib.SMTPException:
                 print "<= Mail: Server doesn't support STARTTLS"
                 if confout.get('force_starttls'):
                     raise
+
+        if confout.get('smtp_user', None):
+            s.login(confout.get('smtp_user'), confout.get('smtp_pass'))
 
         if args.debug:
             print "dst {%s}, msg.as_string {%s}" % (dst, msg.as_string())

--- a/WhatsAppEmailForwarder.py
+++ b/WhatsAppEmailForwarder.py
@@ -147,8 +147,8 @@ class MailLayer(YowInterfaceLayer):
                 if confout.get('force_starttls'):
                     raise
 
-        if confout.get('smtp_user', None):
-            s.login(confout.get('smtp_user'), confout.get('smtp_pass'))
+        if confout.get('user', None):
+            s.login(confout.get('user'), confout.get('pass'))
 
         if args.debug:
             print "dst {%s}, msg.as_string {%s}" % (dst, msg.as_string())


### PR DESCRIPTION
Hi axel-angel,

I made a tiny patch to your whatsapp-email-bridge:

Send EHLO when establishing outgoing SMTP connection as required by many MTA (RFC 2821 4.1.1.1 " A client SMTP SHOULD start an SMTP session by issuing the EHLO
   command.") . Resend EHLO after STARTTLS (see RFC 3207 4.2 "The client SHOULD send an EHLO command as the first command after a successful TLS negotiation").
